### PR TITLE
Call File::sync_all to ensure that all in-memory data successfully reaches the filesystem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ impl Config {
 
             let (mut file, file_path) = self.create_proto_file(package)?;
             write!(file, "{}", SchemaPrinter(&schema_file))?;
+            file.sync_all()?;
 
             in_files.push(file_path);
         }


### PR DESCRIPTION
https://doc.rust-lang.org/std/fs/struct.File.html

> Files are automatically closed when they go out of scope. Errors detected on closing are ignored by the implementation of Drop. Use the method sync_all if these errors must be manually handled.